### PR TITLE
Move getCacheTags from abstractStrategy to strategies

### DIFF
--- a/Media/DisplayBlock/Strategies/DisplayMediaStrategy.php
+++ b/Media/DisplayBlock/Strategies/DisplayMediaStrategy.php
@@ -68,6 +68,16 @@ class DisplayMediaStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string


### PR DESCRIPTION
[OO-BCBREAK] DisplayBundle/DisplayBlock/Strategies/AbstractStrategy:getCacheTags() is now abstract and must therefore be explicitally implemented on each display strategy
https://github.com/open-orchestra/open-orchestra-display-bundle/pull/200
https://github.com/open-orchestra/open-orchestra-media-bundle/pull/166
https://github.com/open-orchestra/open-orchestra-elastica-bundle/pull/17