### PR TITLE
remove deprecated 1.2

### DIFF
--- a/Media/Repository/FolderRepositoryInterface.php
+++ b/Media/Repository/FolderRepositoryInterface.php
@@ -11,6 +11,8 @@ use OpenOrchestra\Media\Model\FolderInterface;
 interface FolderRepositoryInterface
 {
     /**
+     * @deprecated FindAllRootFolder is deprecated since version 1.1.0 and will be removed in 1.3.0. use findAllRootFolderBySiteId
+     *
      * @return Collection
      */
     public function findAllRootFolder();

--- a/Media/Tests/Twig/DisplayMediaExtensionTest.php
+++ b/Media/Tests/Twig/DisplayMediaExtensionTest.php
@@ -56,7 +56,7 @@ class DisplayMediaExtensionTest extends AbstractBaseTestCase
      */
     public function testFunctions()
     {
-        $this->assertCount(6, $this->extension->getFunctions());
+        $this->assertCount(4, $this->extension->getFunctions());
     }
 
     /**
@@ -97,36 +97,6 @@ class DisplayMediaExtensionTest extends AbstractBaseTestCase
         $this->assertSame('', $this->extension->displayMedia($mediaId));
 
         Phake::verify($this->displayMediaManager, Phake::never())->displayMedia($this->media);
-    }
-
-    /**
-     * Test mediaMymType
-     *
-     * @param string $mediaId
-     *
-     * @dataProvider provideMediaId
-     */
-    public function testMediaPreview($mediaId)
-    {
-        $method = 'mediaPreview';
-        $url = 'test.jpg';
-        $this->displayMediaOrPreviewTest($mediaId, $url, $method);
-    }
-
-    /**
-     * Test mediaMymType
-     *
-     * @param string $mediaId
-     *
-     * @dataProvider provideMediaId
-     */
-    public function testMediaPreviewNull($mediaId)
-    {
-        Phake::when($this->mediaRepository)->find(Phake::anyParameters())->thenReturn(null);
-
-        $this->assertSame($this->noMedia, $this->extension->mediaPreview($mediaId));
-
-        Phake::verify($this->displayMediaManager, Phake::never())->displayPreview($this->media);
     }
 
     /**

--- a/Media/Twig/DisplayMediaExtension.php
+++ b/Media/Twig/DisplayMediaExtension.php
@@ -48,12 +48,6 @@ class DisplayMediaExtension extends \Twig_Extension
 
             // Get the alt of a media
             new \Twig_SimpleFunction('get_media_alt', array($this, 'getMediaAlt')),
-
-            // DEPRECATED, NO MORE TO USE
-            new \Twig_SimpleFunction('media_preview', array($this, 'mediaPreview'), array('deprecated' => true)),
-
-            // DEPRECATED, NO MORE TO USE
-            new \Twig_SimpleFunction('get_media_format_url', array($this, 'getMediaUrl'), array('deprecated' => true)),
         );
     }
 
@@ -69,24 +63,6 @@ class DisplayMediaExtension extends \Twig_Extension
 
         if ($media) {
             return $this->displayMediaManager->displayMedia($media, $format);
-        }
-
-        return '';
-    }
-
-    /**
-     * @deprecated will be removed in 1.2.0
-     *
-     * @param String $mediaId
-     *
-     * @return String
-     */
-    public function mediaPreview($mediaId)
-    {
-        $media = $this->getMedia($mediaId);
-
-        if ($media) {
-            return $this->displayMediaManager->displayPreview($media);
         }
 
         return '';

--- a/MediaModelBundle/Repository/FolderRepository.php
+++ b/MediaModelBundle/Repository/FolderRepository.php
@@ -14,11 +14,13 @@ class FolderRepository extends DocumentRepository implements FolderRepositoryInt
     /**
      * @param string|null $siteId
      *
+     * @deprecated FindAllRootFolder is deprecated since version 1.1.0 and will be removed in 1.3.0. use findAllRootFolderBySiteId
+     *
      * @return Collection
      */
     public function findAllRootFolder($siteId = null)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.1.0 and will be removed in 1.2.0. Use the '.__CLASS__.'::findAllRootFolder method instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.1.0 and will be removed in 1.3.0. Use the '.__CLASS__.'::findAllRootFolderBySiteId method instead.', E_USER_DEPRECATED);
 
         $qb = $this->createQueryBuilder();
         $qb->field('parent')->equals(null);


### PR DESCRIPTION
[OO-SUPPRESSED] Twig function media_preview deprecated since 1.1.0 is removed
[OO-SUPPRESSED] Twig function get_media_format_url deprecated since 1.1.0 is removed
[OO-DEPRECATED] Media/Repository/FolderRepositoryInterface: findAllRootFolder is deprecated since version 1.1.0 and will be removed in 1.3.0. use findAllRootFolderBySiteId

https://github.com/open-orchestra/open-orchestra-model-interface/pull/189
https://github.com/open-orchestra/open-orchestra-elastica-bundle/pull/36
https://github.com/open-orchestra/open-orchestra-media-bundle/pull/202
https://github.com/open-orchestra/open-orchestra-model-bundle/pull/588
https://github.com/open-orchestra/open-orchestra-front-bundle/pull/167
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1713